### PR TITLE
Update default gulp task and extend Readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ inside the project directory
 
 run:
 
-    npm -g install
+    npm install
 
 ##### Troubleshooting
 The command above should have installed the packages:
@@ -28,7 +28,7 @@ The command above should have installed the packages:
 
 If you you can install them manually by running:
 
-    npm -g install gulp gulp-concat gulp-connect gulp-open
+    npm install gulp gulp-concat gulp-connect gulp-open
 
 ### development
 
@@ -36,3 +36,14 @@ run:
 
     gulp
 
+This will create a dist/ folder inside app/ containing both css/ and js/ concatenated files.
+
+If for any reason, those folders or files are not created, you could manually run:
+
+    gulp css
+
+or
+
+    gulp js
+
+To generate those directories manually.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,7 @@ gulp.task('watch', function() {
 });
 
 gulp.task('serve', ['connect', 'open', 'watch']);
-gulp.task('default', ['serve']);
+gulp.task('default', ['build', 'serve']);
 gulp.task('build', ['js', 'css']);
 
 gulp.task('serveprod', function() {


### PR DESCRIPTION
Given the gulp task was not working properly, I've updated the default
task to run first build and then serve. Also, I've updated the Readme
content to reflect the NPM installation locally and the troubleshooting
for missing css/js files.
- Update gulp default task.
- Include troubleshooting info for missing CSS and JS files
